### PR TITLE
Remove fdopen dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ These will both be converted to (in Erlang syntax):
 
     {foo, [1, 2, 3]}
 
-Requirements
------
-
-You will need to install the fdopen-php extension:
-http://github.com/dhotson/fdopen-php
-
-
 Usage
 -----
 

--- a/classes/Ernie.php
+++ b/classes/Ernie.php
@@ -83,8 +83,8 @@ class Ernie
 
 	public static function start()
 	{
-		$input = fdopen(3, 'r');
-		$output = fdopen(4, 'w');
+		$input = fopen("php://fd/3", 'r');
+		$output = fopen("php://fd/4", 'w');
 
 		while (true)
 		{


### PR DESCRIPTION
The external fdopen library is no longer required since it has been
implemented in PHP 5.3. See: https://bugs.php.net/bug.php?id=53465
